### PR TITLE
Add useOptions hook for header links

### DIFF
--- a/packages/gatsby-theme-digital-garden/src/components/header.js
+++ b/packages/gatsby-theme-digital-garden/src/components/header.js
@@ -22,11 +22,11 @@ export default () => {
         {title}
       </Styled.a>
       <Box mx="auto" />
-      <Styled.a as={Link} to="/writing">
+      <Styled.a as={Link} to={postsPath || '/writing'}>
         Writing
       </Styled.a>
       <Box mx={1} />
-      <Styled.a as={Link} to={notesPath}>
+      <Styled.a as={Link} to={notesPath || '/notes'}>
         Notes
       </Styled.a>
       <Box mx={1} />

--- a/packages/gatsby-theme-digital-garden/src/components/header.js
+++ b/packages/gatsby-theme-digital-garden/src/components/header.js
@@ -5,9 +5,11 @@ import { Header } from 'theme-ui/layout'
 
 import { Box } from './ui'
 import useSiteMetadata from '../use-site-metadata'
+import useOptions from '../use-options'
 
 export default () => {
   const { title } = useSiteMetadata()
+  const { notesPath, postsPath } = useOptions()
 
   return (
     <Header
@@ -24,7 +26,7 @@ export default () => {
         Writing
       </Styled.a>
       <Box mx={1} />
-      <Styled.a as={Link} to="/txt">
+      <Styled.a as={Link} to={notesPath}>
         Notes
       </Styled.a>
       <Box mx={1} />

--- a/packages/gatsby-theme-digital-garden/src/use-options.js
+++ b/packages/gatsby-theme-digital-garden/src/use-options.js
@@ -1,0 +1,18 @@
+import { graphql, useStaticQuery } from 'gatsby'
+
+export default () => {
+  const data = useStaticQuery(graphql`
+    {
+      sitePlugin(name: { eq: "gatsby-theme-digital-garden" }) {
+        pluginOptions {
+          path
+          name
+          notesPath
+          postsPath
+        }
+      }
+    }
+  `)
+
+  return data.sitePlugin.pluginOptions
+}


### PR DESCRIPTION
I noticed the header had hard-coded routes for `/txt` so this attempts to use plugin options to set the links - lmk if I missed anything here