### PR TITLE
Use Garden Type

### DIFF
--- a/packages/gatsby-theme-digital-garden/gatsby-node.js
+++ b/packages/gatsby-theme-digital-garden/gatsby-node.js
@@ -1,6 +1,7 @@
 const fs = require(`fs`)
 const path = require(`path`)
 const mkdirp = require(`mkdirp`)
+const crypto = require('crypto')
 const Debug = require(`debug`)
 
 const debug = Debug(`gatsby-theme-digital-garden`)
@@ -125,6 +126,38 @@ exports.onCreateWebpackConfig = ({ loaders, actions }) => {
           use: [loaders.js()]
         }
       ]
+    }
+  })
+}
+
+exports.sourceNodes = (
+  { actions: { createTypes, createNode }, schema },
+  { notesPath = '/notes' }
+) => {
+  // Create the Garden type to solidify the field data types
+  createTypes(`type Garden implements Node {
+notesPath: String!
+postsPath: String
+}`)
+
+  // create garden data from plugin config
+  const gardenData = {
+    notesPath
+  }
+
+  createNode({
+    ...gardenData,
+    id: `gatsby-theme-digital-garden-root`,
+    parent: null,
+    children: [],
+    internal: {
+      type: `Garden`,
+      contentDigest: crypto
+        .createHash(`md5`)
+        .update(JSON.stringify(gardenData))
+        .digest(`hex`),
+      content: JSON.stringify(gardenData),
+      description: `Digital Garden Metadata`
     }
   })
 }

--- a/packages/gatsby-theme-digital-garden/src/use-options.js
+++ b/packages/gatsby-theme-digital-garden/src/use-options.js
@@ -3,16 +3,12 @@ import { graphql, useStaticQuery } from 'gatsby'
 export default () => {
   const data = useStaticQuery(graphql`
     {
-      sitePlugin(name: { eq: "gatsby-theme-digital-garden" }) {
-        pluginOptions {
-          path
-          name
-          notesPath
-          postsPath
-        }
+      garden(id: { eq: "gatsby-theme-digital-garden-root" }) {
+        notesPath
+        postsPath
       }
     }
   `)
 
-  return data.sitePlugin.pluginOptions
+  return data.garden
 }


### PR DESCRIPTION
Instead of querying for fields in `site` that might not exist (ex: if
an option isn't set by a user and uses the default), this PR creates a
`Garden` type used the schema customization APIs. Then we set a
specific, known, ID on the node we insert so we can fetch it later and
not have our queries fail due to missing data.

Related to my comments on -- https://github.com/johno/digital-garden/pull/41

Let me know what you think of this approach? Seems like the right move from a query integrity perspective, but this is the first time I'm using the schema customization APIs in this way.