### PR TITLE
Add basic portfolio theme

### DIFF
--- a/packages/gatsby-theme-digital-garden-portfolio/gatsby-config.js
+++ b/packages/gatsby-theme-digital-garden-portfolio/gatsby-config.js
@@ -1,0 +1,22 @@
+const path = require('path')
+const pkg = require('./package.json')
+
+module.exports = options => {
+  return {
+    plugins: [
+      {
+        resolve: 'gatsby-source-filesystem',
+        options: {
+          path: options.projects || 'projects',
+          name: 'projects'
+        }
+      },
+      {
+        resolve: 'gatsby-plugin-compile-es6-packages',
+        options: {
+          modules: [pkg.name]
+        }
+      }
+    ]
+  }
+}

--- a/packages/gatsby-theme-digital-garden-portfolio/gatsby-node.js
+++ b/packages/gatsby-theme-digital-garden-portfolio/gatsby-node.js
@@ -47,12 +47,12 @@ exports.createPages = async ({ graphql, actions }, opts) => {
   }
 
   const { mdxPages } = result.data
-  const posts = mdxPages.edges.filter(
+  const projects = mdxPages.edges.filter(
     ({ node }) => node.parent.sourceInstanceName === 'projects'
   )
 
-  // Create posts pages
-  posts.forEach(({ node }) => {
+  // Create projects pages
+  projects.forEach(({ node }) => {
     createPage({
       path: node.frontmatter.path || toProjectsPath(node),
       context: node,

--- a/packages/gatsby-theme-digital-garden-portfolio/gatsby-node.js
+++ b/packages/gatsby-theme-digital-garden-portfolio/gatsby-node.js
@@ -1,0 +1,78 @@
+const path = require('path')
+const mkdirp = require('mkdirp')
+const Debug = require('debug')
+const pkg = require('./package.json')
+
+const debug = Debug(pkg.name)
+
+const Project = require.resolve('./src/templates/project')
+const Projects = require.resolve('./src/templates/projects')
+
+exports.createPages = async ({ graphql, actions }, opts) => {
+  const { createPage } = actions
+  const { projectsPath = '/work' } = opts
+
+  const toProjectsPath = node => {
+    const { dir } = path.parse(node.parent.relativePath)
+    return path.join(projectsPath, dir, node.parent.name)
+  }
+
+  const result = await graphql(`
+    {
+      mdxPages: allMdx(sort: { fields: [frontmatter___date], order: DESC }) {
+        edges {
+          node {
+            id
+            frontmatter {
+              path
+              title
+            }
+            parent {
+              ... on File {
+                name
+                base
+                relativePath
+                sourceInstanceName
+              }
+            }
+          }
+        }
+      }
+    }
+  `)
+
+  if (result.errors) {
+    console.log(result.errors)
+    throw new Error(`Could not query projects`, result.errors)
+  }
+
+  const { mdxPages } = result.data
+  const posts = mdxPages.edges.filter(
+    ({ node }) => node.parent.sourceInstanceName === 'projects'
+  )
+
+  // Create posts pages
+  posts.forEach(({ node }) => {
+    createPage({
+      path: node.frontmatter.path || toProjectsPath(node),
+      context: node,
+      component: Project
+    })
+  })
+
+  createPage({
+    path: projectsPath,
+    component: Projects
+  })
+}
+
+exports.onPreBootstrap = ({ store }, opts) => {
+  const { program } = store.getState()
+
+  const dirs = [path.join(program.directory, opts.projects || `projects`)]
+
+  dirs.forEach(dir => {
+    debug(`Initializing ${dir} directory`)
+    mkdirp.sync(dir)
+  })
+}

--- a/packages/gatsby-theme-digital-garden-portfolio/package.json
+++ b/packages/gatsby-theme-digital-garden-portfolio/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "gatsby-theme-digital-garden-portfolio",
+  "version": "0.0.21",
+  "main": "index.js",
+  "author": "Brent Jackson <jxnblk@gmail.com>",
+  "license": "MIT",
+  "keywords": [
+    "gatsby",
+    "gatsby-theme",
+    "react"
+  ],
+  "devDependencies": {
+    "gatsby": "^2.1.32",
+    "react": "^16.8.4",
+    "react-dom": "^16.8.4"
+  },
+  "peerDependencies": {
+    "gatsby": "^2.1.32",
+    "react": "^16.8.4",
+    "react-dom": "^16.8.4"
+  },
+  "dependencies": {
+    "debug": "^4.1.1",
+    "gatsby-plugin-compile-es6-packages": "^1.1.0",
+    "gatsby-plugin-page-creator": "^2.0.12",
+    "gatsby-source-filesystem": "^2.0.29",
+    "mkdirp": "^0.5.1"
+  }
+}

--- a/packages/gatsby-theme-digital-garden-portfolio/src/templates/project.js
+++ b/packages/gatsby-theme-digital-garden-portfolio/src/templates/project.js
@@ -11,9 +11,7 @@ export const pageQuery = graphql`
       frontmatter {
         title
         description
-        date
         image
-        url
       }
       code {
         body

--- a/packages/gatsby-theme-digital-garden-portfolio/src/templates/project.js
+++ b/packages/gatsby-theme-digital-garden-portfolio/src/templates/project.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import { graphql } from 'gatsby'
+import Project from '../components/project'
+
+export default Project
+
+export const pageQuery = graphql`
+  query($id: String!) {
+    project: mdx(id: { eq: $id }) {
+      id
+      frontmatter {
+        title
+        description
+        date
+        image
+        url
+      }
+      code {
+        body
+      }
+    }
+  }
+`

--- a/packages/gatsby-theme-digital-garden-portfolio/src/templates/projects.js
+++ b/packages/gatsby-theme-digital-garden-portfolio/src/templates/projects.js
@@ -16,7 +16,7 @@ export default ({
 
 export const pageQuery = graphql`
   query ProjectList {
-    allMdx(sort: { fields: [frontmatter___date], order: DESC }) {
+    allMdx(sort: { fields: [frontmatter___order], order: ASC }) {
       edges {
         node {
           id
@@ -29,6 +29,8 @@ export const pageQuery = graphql`
           frontmatter {
             title
             path
+            description
+            image
           }
         }
       }

--- a/packages/gatsby-theme-digital-garden-portfolio/src/templates/projects.js
+++ b/packages/gatsby-theme-digital-garden-portfolio/src/templates/projects.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import { graphql } from 'gatsby'
+import Projects from '../components/projects'
+
+export default ({
+  data: {
+    allMdx: { edges }
+  }
+}) => {
+  const projects = edges
+    .filter(({ node }) => node.parent.sourceInstanceName === 'projects')
+    .map(edge => edge.node)
+
+  return <Projects projects={projects} />
+}
+
+export const pageQuery = graphql`
+  query ProjectList {
+    allMdx(sort: { fields: [frontmatter___date], order: DESC }) {
+      edges {
+        node {
+          id
+          parent {
+            ... on File {
+              name
+              sourceInstanceName
+            }
+          }
+          frontmatter {
+            title
+            path
+          }
+        }
+      }
+    }
+  }
+`

--- a/packages/gatsby-theme-digital-garden/src/components/background-image.js
+++ b/packages/gatsby-theme-digital-garden/src/components/background-image.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { css } from 'theme-ui'
+
+export default ({ ratio = 3 / 4, src, ...props }) => (
+  <div
+    {...props}
+    css={css({
+      width: '100%',
+      height: 0,
+      paddingBottom: ratio * 100 + '%',
+      backgroundSize: 'cover',
+      backgroundPosition: 'center',
+      backgroundImage: `url(${src})`
+    })}
+  />
+)

--- a/packages/gatsby-theme-digital-garden/src/gatsby-theme-digital-garden-portfolio/components/project.js
+++ b/packages/gatsby-theme-digital-garden/src/gatsby-theme-digital-garden-portfolio/components/project.js
@@ -1,35 +1,18 @@
 import React from 'react'
 import MDXRenderer from 'gatsby-mdx/mdx-renderer'
 import { Styled, css } from 'theme-ui'
-import { ExternalLink } from 'react-feather'
 import Layout from '../../components/layout'
 
 export default ({
   data: {
     project: {
-      frontmatter: { title, description, date, url, image },
+      frontmatter: { title, description, image },
       code
     }
   }
 }) => (
   <Layout>
-    <Styled.h1>
-      {title}
-      {url && (
-        <Styled.a
-          href={url}
-          title="View original"
-          css={css({
-            mx: 2,
-            display: 'inline-flex',
-            alignItems: 'center'
-          })}
-        >
-          {' '}
-          <ExternalLink />
-        </Styled.a>
-      )}
-    </Styled.h1>
+    <Styled.h1>{title}</Styled.h1>
     <Styled.p>{description}</Styled.p>
     {image && <Styled.img src={image} />}
     <MDXRenderer children={code.body} />

--- a/packages/gatsby-theme-digital-garden/src/gatsby-theme-digital-garden-portfolio/components/project.js
+++ b/packages/gatsby-theme-digital-garden/src/gatsby-theme-digital-garden-portfolio/components/project.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import MDXRenderer from 'gatsby-mdx/mdx-renderer'
+import { Styled, css } from 'theme-ui'
+import { ExternalLink } from 'react-feather'
+import Layout from '../../components/layout'
+
+export default ({
+  data: {
+    project: {
+      frontmatter: { title, description, date, url, image },
+      code
+    }
+  }
+}) => (
+  <Layout>
+    <Styled.h1>
+      {title}
+      {url && (
+        <Styled.a
+          href={url}
+          title="View original"
+          css={css({
+            mx: 2,
+            display: 'inline-flex',
+            alignItems: 'center'
+          })}
+        >
+          {' '}
+          <ExternalLink />
+        </Styled.a>
+      )}
+    </Styled.h1>
+    <Styled.p>{description}</Styled.p>
+    {image && <Styled.img src={image} />}
+    <MDXRenderer children={code.body} />
+  </Layout>
+)

--- a/packages/gatsby-theme-digital-garden/src/gatsby-theme-digital-garden-portfolio/components/project.js
+++ b/packages/gatsby-theme-digital-garden/src/gatsby-theme-digital-garden-portfolio/components/project.js
@@ -12,8 +12,20 @@ export default ({
   }
 }) => (
   <Layout>
-    <Styled.h1>{title}</Styled.h1>
-    <Styled.p>{description}</Styled.p>
+    <Styled.h1
+      css={css({
+        mb: 0
+      })}
+    >
+      {title}
+    </Styled.h1>
+    <Styled.p
+      css={css({
+        mt: 0
+      })}
+    >
+      {description}
+    </Styled.p>
     {image && <Styled.img src={image} />}
     <MDXRenderer children={code.body} />
   </Layout>

--- a/packages/gatsby-theme-digital-garden/src/gatsby-theme-digital-garden-portfolio/components/projects.js
+++ b/packages/gatsby-theme-digital-garden/src/gatsby-theme-digital-garden-portfolio/components/projects.js
@@ -1,8 +1,9 @@
 import React from 'react'
 import { Link } from 'gatsby'
-import { Styled } from 'theme-ui'
+import { Styled, css } from 'theme-ui'
 
 import Layout from '../../components/layout'
+import BackgroundImage from '../../components/background-image'
 
 export default ({ projects }) => (
   <Layout>
@@ -34,9 +35,15 @@ export default ({ projects }) => (
               textDecoration: 'none'
             })}
           >
-            <Styled.img src={project.frontmatter.image} />
-            <Styled.h3>{project.frontmatter.title}</Styled.h3>
-            <Styled.p>{project.frontmatter.title}</Styled.p>
+            <BackgroundImage src={project.frontmatter.image} />
+            <Styled.h3
+              css={css({
+                mb: 0
+              })}
+            >
+              {project.frontmatter.title}
+            </Styled.h3>
+            <Styled.p css={css({ m: 0 })}>{project.frontmatter.title}</Styled.p>
           </Link>
         </li>
       ))}

--- a/packages/gatsby-theme-digital-garden/src/gatsby-theme-digital-garden-portfolio/components/projects.js
+++ b/packages/gatsby-theme-digital-garden/src/gatsby-theme-digital-garden-portfolio/components/projects.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import { Link } from 'gatsby'
+import { Styled } from 'theme-ui'
+
+import Layout from '../../components/layout'
+
+export default ({ projects }) => (
+  <Layout>
+    <ul>
+      {projects.map(project => (
+        <li key={project.id}>
+          <Link to={project.frontmatter.path}>{project.frontmatter.title}</Link>
+        </li>
+      ))}
+    </ul>
+  </Layout>
+)

--- a/packages/gatsby-theme-digital-garden/src/gatsby-theme-digital-garden-portfolio/components/projects.js
+++ b/packages/gatsby-theme-digital-garden/src/gatsby-theme-digital-garden-portfolio/components/projects.js
@@ -6,10 +6,38 @@ import Layout from '../../components/layout'
 
 export default ({ projects }) => (
   <Layout>
-    <ul>
+    <ul
+      css={{
+        listStyle: 'none',
+        padding: 0,
+        margin: 0,
+        display: 'flex',
+        flexWrap: 'wrap',
+        justifyContent: 'stretch'
+      }}
+    >
       {projects.map(project => (
-        <li key={project.id}>
-          <Link to={project.frontmatter.path}>{project.frontmatter.title}</Link>
+        <li
+          key={project.id}
+          css={{
+            flexGrow: 1,
+            flexShrink: 0,
+            flexBasis: 256,
+            padding: 32
+          }}
+        >
+          <Link
+            to={project.frontmatter.path}
+            css={theme => ({
+              display: 'block',
+              color: 'inherit',
+              textDecoration: 'none'
+            })}
+          >
+            <Styled.img src={project.frontmatter.image} />
+            <Styled.h3>{project.frontmatter.title}</Styled.h3>
+            <Styled.p>{project.frontmatter.title}</Styled.p>
+          </Link>
         </li>
       ))}
     </ul>

--- a/site/gatsby-config.js
+++ b/site/gatsby-config.js
@@ -11,6 +11,13 @@ module.exports = {
       options: {
         postsPath: '/writing'
       }
+    },
+    {
+      resolve: 'gatsby-theme-digital-garden-portfolio',
+      options: {
+        projectsPath: '/work',
+        projects: 'projects'
+      }
     }
   ],
   siteMetadata: {

--- a/site/package.json
+++ b/site/package.json
@@ -10,6 +10,7 @@
     "gatsby": "^2.1.32",
     "gatsby-theme-digital-garden": "*",
     "gatsby-theme-digital-garden-blog": "*",
+    "gatsby-theme-digital-garden-portfolio": "*",
     "react": "^16.8.4",
     "react-dom": "^16.8.4"
   }

--- a/site/projects/cats-coffee-code.mdx
+++ b/site/projects/cats-coffee-code.mdx
@@ -1,10 +1,9 @@
 ---
 title: Cats, Coffee & Code
-date: 2012-08-01
+order: 1
 path: /work/cats-coffee-code
-url: https://dribbble.com/shots/670755-A-great-way-to-start-the-day
 image: https://cdn.dribbble.com/users/2014/screenshots/670755/catscoffeecode.png
 description: A great way to start the day
 ---
 
-![cats, coffee & code illustration](https://cdn.dribbble.com/users/2014/screenshots/670755/catscoffeecode.png)
+[View on Dribbble](https://dribbble.com/shots/670755-A-great-way-to-start-the-day)

--- a/site/projects/cats-coffee-code.mdx
+++ b/site/projects/cats-coffee-code.mdx
@@ -1,0 +1,10 @@
+---
+title: Cats, Coffee & Code
+date: 2012-08-01
+path: /work/cats-coffee-code
+url: https://dribbble.com/shots/670755-A-great-way-to-start-the-day
+image: https://cdn.dribbble.com/users/2014/screenshots/670755/catscoffeecode.png
+description: A great way to start the day
+---
+
+![cats, coffee & code illustration](https://cdn.dribbble.com/users/2014/screenshots/670755/catscoffeecode.png)

--- a/site/projects/digital-garden-logo.mdx
+++ b/site/projects/digital-garden-logo.mdx
@@ -1,0 +1,27 @@
+---
+title: Digital Garden Logo
+date: 2019-04-16
+path: /work/digital-garden-logo
+description: A logo for Gatsby Theme Digital Garden
+---
+
+<svg viewBox="0 0 32 32" width={128} height={128} fill="pink">
+  <path
+    d={`
+      M 26.46162167924669 19.399186938124423
+      A 4 4 0 0 1 16 27
+      A 4 4 0 0 1 5.538378320753312 19.399186938124423
+      A 4 4 0 0 1 9.534362224782793 7.100813061875579
+      A 4 4 0 0 1 22.465637775217203 7.100813061875577
+      A 4 4 0 0 1 26.46162167924669 19.399186938124423
+      M 16 10
+      A 6 6 0 0 0 16 22
+      A 6 6 0 0 0 16 10
+      z
+    `}
+  />
+</svg>
+
+<!--
+This is just demo content, you don't actually have to use this
+-->

--- a/site/projects/digital-garden-logo.mdx
+++ b/site/projects/digital-garden-logo.mdx
@@ -1,26 +1,10 @@
 ---
+order: 0
 title: Digital Garden Logo
-date: 2019-04-16
 path: /work/digital-garden-logo
+image: https://notebook.jxnblk.com/flower.png
 description: A logo for Gatsby Theme Digital Garden
 ---
-
-<svg viewBox="0 0 32 32" width={128} height={128} fill="pink">
-  <path
-    d={`
-      M 26.46162167924669 19.399186938124423
-      A 4 4 0 0 1 16 27
-      A 4 4 0 0 1 5.538378320753312 19.399186938124423
-      A 4 4 0 0 1 9.534362224782793 7.100813061875579
-      A 4 4 0 0 1 22.465637775217203 7.100813061875577
-      A 4 4 0 0 1 26.46162167924669 19.399186938124423
-      M 16 10
-      A 6 6 0 0 0 16 22
-      A 6 6 0 0 0 16 10
-      z
-    `}
-  />
-</svg>
 
 <!--
 This is just demo content, you don't actually have to use this

--- a/yarn.lock
+++ b/yarn.lock
@@ -5905,7 +5905,7 @@ gatsby-react-router-scroll@^2.0.7:
     scroll-behavior "^0.9.9"
     warning "^3.0.0"
 
-gatsby-source-filesystem@^2.0.25:
+gatsby-source-filesystem@^2.0.25, gatsby-source-filesystem@^2.0.29:
   version "2.0.29"
   resolved "https://registry.yarnpkg.com/gatsby-source-filesystem/-/gatsby-source-filesystem-2.0.29.tgz#2cc2746072d8bb60d5818cd64bcd7e7754873090"
   integrity sha512-Eeh4C2iBIE8rCooIF/oE7l5nH6aYMw1RLpvwiQl8qNhBUM8JHqKAm+UpKrkb9uZ/Jj8OTB9wW2LcoJkCE5iKew==


### PR DESCRIPTION
Adds an MDX-based portfolio theme

## Todo/questions:

- [x] How should path/slugs work? Is using `path` in frontmatter the preferred approach here? - frontmatter will be required to start
- [x] ~~Should this use the custom types api to better handle frontmatter/metadata?~~ punting for now
- [x] `s/posts/projects`
- [x] ~~How do we want to leverage Gatsby Image here?~~ punting for now
- [x] Should we just roll with YAML instead of MDX??? – sticking with MDX
- [x] What fields should the frontmatter support
- [ ] Should this include any changes to how the header is generated?
- [ ] Make sure this makes sense for multiple images, photography, and other types of portfolios