### PR TITLE
Improve header component boundaries for shadowing

### DIFF
--- a/packages/gatsby-theme-digital-garden/src/components/header-container.js
+++ b/packages/gatsby-theme-digital-garden/src/components/header-container.js
@@ -1,0 +1,11 @@
+import React from 'react'
+
+import Header from './header'
+import useOptions from '../use-options'
+
+export default () => {
+  const { header } = useOptions()
+  const { home, links } = header
+
+  return <Header home={home} links={links} />
+}

--- a/packages/gatsby-theme-digital-garden/src/components/header.js
+++ b/packages/gatsby-theme-digital-garden/src/components/header.js
@@ -3,11 +3,9 @@ import { css } from 'theme-ui'
 import { Header } from 'theme-ui/layout'
 
 import HeaderLink from './header-link'
-import useOptions from '../use-options'
 
-export default () => {
-  const { header } = useOptions()
-  const { home, links } = header
+export default props => {
+  const { home, links } = props
 
   return (
     <Header

--- a/packages/gatsby-theme-digital-garden/src/components/layout.js
+++ b/packages/gatsby-theme-digital-garden/src/components/layout.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { Global } from '@emotion/core'
 import { css } from 'theme-ui'
 import { Layout, Main, Container } from 'theme-ui/layout'
-import Header from './header'
+import HeaderContainer from './header-container'
 import { SEO } from './seo'
 
 export default props => (
@@ -22,7 +22,7 @@ export default props => (
     />
     <Layout>
       <SEO />
-      <Header />
+      <HeaderContainer />
       <Main>
         <Container>{props.children}</Container>
       </Main>


### PR DESCRIPTION
* Allows for easier component shadowing of header by any component that can handle `home` and `links` props
* Doesn't require shadowing of additional other functions such as `use-options`