### PR TITLE
Update readme to no longer use deprecated __experimentalThemes key

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,8 +35,11 @@ theme:
 ```js
 // gatsby-config.js
 module.exports = {
-  __experimentalThemes: [
-    'gatsby-theme-digital-garden'
+  plugins: [
+    {
+      resolve: 'gatsby-theme-digital-garden',
+      options: {}
+    }
   ]
 }
 ```


### PR DESCRIPTION
This brings the readme to parity with the `gatsby-config.js` examples in
the `examples` directory. See: https://www.gatsbyjs.org/blog/2019-07-03-announcing-stable-release-gatsby-themes/#what-is-different